### PR TITLE
RabbitMQMessageScheme: Don't crash if headers is null

### DIFF
--- a/src/main/java/io/latent/storm/rabbitmq/RabbitMQMessageScheme.java
+++ b/src/main/java/io/latent/storm/rabbitmq/RabbitMQMessageScheme.java
@@ -80,6 +80,9 @@ public class RabbitMQMessageScheme implements MessageScheme {
   }
 
   private Map<String, Object> serialiazableHeaders(Map<String, Object> headers) {
+    if (headers == null) {
+      return new HashMap<String, Object>();
+    }
     Map<String, Object> serializableHeaders = new HashMap<String, Object>(headers.size());
     for (Map.Entry<String, Object> entry : headers.entrySet()) {
       if (entry.getValue() instanceof Number ||


### PR DESCRIPTION
If there is no headers returned from RabbitMQ, just return empty HashMap (otherwise, it will crash with NPE)
