### PR TITLE
Allow ConnectionConfig to use either URI or named parameters.

### DIFF
--- a/src/main/java/io/latent/storm/rabbitmq/config/ConnectionConfig.java
+++ b/src/main/java/io/latent/storm/rabbitmq/config/ConnectionConfig.java
@@ -3,95 +3,134 @@ package io.latent.storm.rabbitmq.config;
 import com.rabbitmq.client.ConnectionFactory;
 
 import java.io.Serializable;
+import java.net.URISyntaxException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static io.latent.storm.rabbitmq.config.ConfigUtils.*;
+import static io.latent.storm.rabbitmq.config.ConfigUtils.addToMap;
+import static io.latent.storm.rabbitmq.config.ConfigUtils.getFromMap;
+import static io.latent.storm.rabbitmq.config.ConfigUtils.getFromMapAsInt;
 
 public class ConnectionConfig implements Serializable {
-  private final String host;
-  private final int port;
-  private final String username;
-  private final String password;
-  private final String virtualHost;
-  private final int heartBeat;
 
-  public static ConnectionConfig forTest() {
-    return new ConnectionConfig(ConnectionFactory.DEFAULT_HOST, ConnectionFactory.DEFAULT_USER, ConnectionFactory.DEFAULT_PASS);
-  }
+    // Use named parameters
+    private String host;
+    private int port;
+    private String username;
+    private String password;
+    private String virtualHost;
+    private int heartBeat;
 
-  public ConnectionConfig(String host,
-                          String username,
-                          String password) {
-    this(host, ConnectionFactory.DEFAULT_AMQP_PORT, username, password, ConnectionFactory.DEFAULT_VHOST, 10);
-  }
+    // Use AMQP URI http://www.rabbitmq.com/uri-spec.html
+    private String uri;
 
-  public ConnectionConfig(String host,
-                          int port,
-                          String username,
-                          String password,
-                          String virtualHost,
-                          int heartBeat) {
-    this.host = host;
-    this.port = port;
-    this.username = username;
-    this.password = password;
-    this.virtualHost = virtualHost;
-    this.heartBeat = heartBeat;
-  }
+    public static ConnectionConfig forTest() {
+        return new ConnectionConfig(ConnectionFactory.DEFAULT_HOST, ConnectionFactory.DEFAULT_USER, ConnectionFactory.DEFAULT_PASS);
+    }
 
-  public String getHost() {
-    return host;
-  }
+    public ConnectionConfig(String uri) {
+        this.uri = uri;
+    }
 
-  public int getPort() {
-    return port;
-  }
+    public ConnectionConfig(String host,
+                            String username,
+                            String password) {
+        this(host, ConnectionFactory.DEFAULT_AMQP_PORT, username, password, ConnectionFactory.DEFAULT_VHOST, 10);
+    }
 
-  public String getUsername() {
-    return username;
-  }
+    public ConnectionConfig(String host,
+                            int port,
+                            String username,
+                            String password,
+                            String virtualHost,
+                            int heartBeat) {
+        this.host = host;
+        this.port = port;
+        this.username = username;
+        this.password = password;
+        this.virtualHost = virtualHost;
+        this.heartBeat = heartBeat;
+    }
 
-  public String getPassword() {
-    return password;
-  }
+    public String getHost() {
+        return host;
+    }
 
-  public String getVirtualHost() {
-    return virtualHost;
-  }
+    public int getPort() {
+        return port;
+    }
 
-  public int getHeartBeat() {
-    return heartBeat;
-  }
+    public String getUsername() {
+        return username;
+    }
 
-  public ConnectionFactory asConnectionFactory() {
-    ConnectionFactory factory = new ConnectionFactory();
-    factory.setHost(host);
-    factory.setPort(port);
-    factory.setUsername(username);
-    factory.setPassword(password);
-    factory.setVirtualHost(virtualHost);
-    factory.setRequestedHeartbeat(heartBeat);
-    return factory;
-  }
+    public String getPassword() {
+        return password;
+    }
 
-  public static ConnectionConfig getFromStormConfig(Map<String, Object> stormConfig) {
-    return new ConnectionConfig(getFromMap("rabbitmq.host", stormConfig),
-                                getFromMapAsInt("rabbitmq.port", stormConfig),
-                                getFromMap("rabbitmq.username", stormConfig),
-                                getFromMap("rabbitmq.password", stormConfig),
-                                getFromMap("rabbitmq.virtualhost", stormConfig),
-                                getFromMapAsInt("rabbitmq.heartbeat", stormConfig));
-  }
+    public String getVirtualHost() {
+        return virtualHost;
+    }
 
-  public Map<String, Object> asMap() {
-    Map<String, Object> map = new HashMap<String, Object>();
-    addToMap("rabbitmq.host", map, host);
-    addToMap("rabbitmq.port", map, port);
-    addToMap("rabbitmq.username", map, username);
-    addToMap("rabbitmq.password", map, password);
-    addToMap("rabbitmq.virtualhost", map, virtualHost);
-    addToMap("rabbitmq.heartbeat", map, heartBeat);
-    return map;
-  }
+    public int getHeartBeat() {
+        return heartBeat;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public ConnectionFactory asConnectionFactory() {
+        ConnectionFactory factory = new ConnectionFactory();
+        if (uri != null) {
+            try {
+                factory.setUri(uri);
+            } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
+            } catch (NoSuchAlgorithmException e) {
+                throw new RuntimeException(e);
+            } catch (KeyManagementException e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            factory.setHost(host);
+            factory.setPort(port);
+            factory.setUsername(username);
+            factory.setPassword(password);
+            factory.setVirtualHost(virtualHost);
+            factory.setRequestedHeartbeat(heartBeat);
+        }
+        return factory;
+    }
+
+    public static ConnectionConfig getFromStormConfig(Map<String, Object> stormConfig) {
+        String uri = getFromMap("rabbitmq.uri", stormConfig);
+        if (uri != null) {
+            return new ConnectionConfig(uri);
+        } else {
+            return new ConnectionConfig(getFromMap("rabbitmq.host", stormConfig),
+                    getFromMapAsInt("rabbitmq.port", stormConfig),
+                    getFromMap("rabbitmq.username", stormConfig),
+                    getFromMap("rabbitmq.password", stormConfig),
+                    getFromMap("rabbitmq.virtualhost", stormConfig),
+                    getFromMapAsInt("rabbitmq.heartbeat", stormConfig));
+        }
+    }
+
+    public Map<String, Object> asMap() {
+        Map<String, Object> map = new HashMap<String, Object>();
+        if (uri != null) {
+            addToMap("rabbitmq.uri", map, uri);
+        } else {
+            addToMap("rabbitmq.host", map, host);
+            addToMap("rabbitmq.port", map, port);
+            addToMap("rabbitmq.username", map, username);
+            addToMap("rabbitmq.password", map, password);
+            addToMap("rabbitmq.virtualhost", map, virtualHost);
+            addToMap("rabbitmq.heartbeat", map, heartBeat);
+        }
+        return map;
+    }
 }


### PR DESCRIPTION
AMQP URI is a nicer (at least in my PoV) way to configure complex RabbitMQ remote connections
http://www.rabbitmq.com/uri-spec.html
http://www.rabbitmq.com/uri-query-parameters.html
- Add new "rabbitmq.uri" parameter
- Return RuntimeException in case of malformed or invalid URI
