### PR TITLE
Conditional publishing

### DIFF
--- a/src/main/java/io/latent/storm/rabbitmq/ConditionalPublishingRabbitMQBolt.java
+++ b/src/main/java/io/latent/storm/rabbitmq/ConditionalPublishingRabbitMQBolt.java
@@ -1,0 +1,33 @@
+package io.latent.storm.rabbitmq;
+
+import backtype.storm.tuple.Tuple;
+
+/**
+ * Simple extension of {@link io.latent.storm.rabbitmq.RabbitMQBolt} that provides the ability to determine whether a message should be published
+ * based on the input tuple
+ * This class is sort of an SPI meaning that it is meant to be subclassed
+ * and the method {@link io.latent.storm.rabbitmq.ConditionalPublishingRabbitMQBolt#shouldPublish}
+ * to be overridden with the custom decision logic
+ */
+public class ConditionalPublishingRabbitMQBolt extends RabbitMQBolt {
+
+    public ConditionalPublishingRabbitMQBolt(TupleToMessage scheme) {
+        super(scheme);
+    }
+
+    public ConditionalPublishingRabbitMQBolt(TupleToMessage scheme, Declarator declarator) {
+        super(scheme, declarator);
+    }
+
+    @Override
+    public void execute(final Tuple tuple) {
+        if(shouldPublish(tuple)) {
+            publish(tuple);
+        }
+        acknowledge(tuple);
+    }
+
+    protected boolean shouldPublish(Tuple tuple) {
+        return true;
+    }
+}

--- a/src/main/java/io/latent/storm/rabbitmq/RabbitMQBolt.java
+++ b/src/main/java/io/latent/storm/rabbitmq/RabbitMQBolt.java
@@ -44,7 +44,7 @@ public class RabbitMQBolt extends BaseRichBolt {
   public void prepare(@SuppressWarnings("rawtypes") final Map stormConf, final TopologyContext context, final OutputCollector collector) {
     producer = new RabbitMQProducer(declarator);
     producer.open(stormConf);
-    logger = LoggerFactory.getLogger(RabbitMQProducer.class);
+    logger = LoggerFactory.getLogger(this.getClass());
     this.collector = collector;
     this.scheme.prepare(stormConf);
     logger.info("Successfully prepared RabbitMQBolt");
@@ -52,13 +52,21 @@ public class RabbitMQBolt extends BaseRichBolt {
 
   @Override
   public void execute(final Tuple tuple) {
-    producer.send(scheme.produceMessage(tuple));
-    // tuples are always acked, even when transformation by scheme yields Message.NONE as
+      publish(tuple);
+      // tuples are always acked, even when transformation by scheme yields Message.NONE as
     // if it failed once it's unlikely to succeed when re-attempted (i.e. serialization/deserilization errors).
-    collector.ack(tuple);
+      acknowledge(tuple);
   }
 
-  @Override
+    protected void acknowledge(Tuple tuple) {
+        collector.ack(tuple);
+    }
+
+    protected void publish(Tuple tuple) {
+        producer.send(scheme.produceMessage(tuple));
+    }
+
+    @Override
   public void declareOutputFields(final OutputFieldsDeclarer declarer) {
     //No fields are emitted from this drain.
   }


### PR DESCRIPTION
Added a simple extension of `RabbitMQBolt` that can be used as a parent for classes that need to decide whether to publish a message on a tuple basis.

The same functionality could be achieved by adding the `shouldPublish` method to `TupleToMessage` and not adding a new subclass of `RabbitMQBolt`, but I thought that this approach was more clean since it preserves the semantics of `TupleToMessage` (convert a Storm Tuple to a RabbitMQ message).

We could also completely ditch `ConditionalPublishingRabbitMQBolt` and add the functionality in `RabbitMQBolt`. 

Let me know what you think.

Thanks,
George