### PR TITLE
Fixed typo in method name

### DIFF
--- a/src/main/java/io/latent/storm/rabbitmq/TupleToMessage.java
+++ b/src/main/java/io/latent/storm/rabbitmq/TupleToMessage.java
@@ -27,7 +27,7 @@ public abstract class TupleToMessage implements Serializable {
   protected Message produceMessage(Tuple input) {
     return Message.forSending(
         extractBody(input),
-        specifiyHeaders(input),
+        specifyHeaders(input),
         determineExchangeName(input),
         determineRoutingKey(input),
         specifyContentType(input),
@@ -74,7 +74,7 @@ public abstract class TupleToMessage implements Serializable {
    * @param input the incoming tuple
    * @return the headers as a map
    */
-  protected Map<String, Object> specifiyHeaders(Tuple input)
+  protected Map<String, Object> specifyHeaders(Tuple input)
   {
     return new HashMap<String, Object>();
   }


### PR DESCRIPTION
`specifiyHeaders` was corrected to `specifyHeaders`.

This change will obviously break code that uses the library and has classes that extend `TupleToMessage` by overriding the method, but I think that it's not much of an issue due the following facts:

* The change is trivial so any codebase extending `TupleToMessage` can make the necessary code update in seconds
* The version of the library is pre 1.x so breaking changes are to be expected