### PR TITLE
Fixed NPE in getFromMap with String and HaHosts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,12 @@
             <artifactId>slf4j-api</artifactId>
             <version>1.7.5</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.10</version>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/src/main/java/io/latent/storm/rabbitmq/Message.java
+++ b/src/main/java/io/latent/storm/rabbitmq/Message.java
@@ -1,10 +1,10 @@
 package io.latent.storm.rabbitmq;
 
+import com.rabbitmq.client.QueueingConsumer;
+
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-
-import com.rabbitmq.client.QueueingConsumer;
 
 public class Message {
   public static final Message NONE = new None();
@@ -25,9 +25,11 @@ public class Message {
                                    String routingKey,
                                    String contentType,
                                    String contentEncoding,
+                                   String expiration,
                                    boolean persistent) {
     return (body != null && exchangeName != null && exchangeName.length() > 0) ?
-        new MessageForSending(body, headers, exchangeName, routingKey, contentType, contentEncoding, persistent) :
+        new MessageForSending(body, headers, exchangeName, routingKey, contentType, contentEncoding, expiration,
+                persistent) :
         NONE;
   }
 
@@ -113,6 +115,7 @@ public class Message {
     private final String contentType;
     private final String contentEncoding;
     private final boolean persistent;
+    private final String expiration;
 
     private MessageForSending(byte[] body,
                               Map<String, Object> headers,
@@ -120,6 +123,7 @@ public class Message {
                               String routingKey,
                               String contentType,
                               String contentEncoding,
+                              String expiration,
                               boolean persistent) {
       super(body);
       this.headers = (headers != null) ? headers : new HashMap<String, Object>();
@@ -127,6 +131,7 @@ public class Message {
       this.routingKey = routingKey;
       this.contentType = contentType;
       this.contentEncoding = contentEncoding;
+      this.expiration = expiration;
       this.persistent = persistent;
     }
 
@@ -153,6 +158,10 @@ public class Message {
     public String getContentEncoding()
     {
       return contentEncoding;
+    }
+
+    public String getExpiration() {
+      return expiration;
     }
 
     public boolean isPersistent()

--- a/src/main/java/io/latent/storm/rabbitmq/RabbitMQProducer.java
+++ b/src/main/java/io/latent/storm/rabbitmq/RabbitMQProducer.java
@@ -56,6 +56,7 @@ public class RabbitMQProducer implements Serializable {
                                                                 .contentEncoding(message.getContentEncoding())
                                                                 .deliveryMode((message.isPersistent()) ? 2 : 1)
                                                                 .headers(message.getHeaders())
+                                                                .expiration(message.getExpiration())
                                                                 .build();
       channel.basicPublish(message.getExchangeName(), message.getRoutingKey(), properties, message.getBody());
     } catch (AlreadyClosedException ace) {

--- a/src/main/java/io/latent/storm/rabbitmq/TupleToMessage.java
+++ b/src/main/java/io/latent/storm/rabbitmq/TupleToMessage.java
@@ -1,10 +1,10 @@
 package io.latent.storm.rabbitmq;
 
+import backtype.storm.tuple.Tuple;
+
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
-
-import backtype.storm.tuple.Tuple;
 
 /**
  * This interface describes an object that will perform the work of mapping
@@ -32,6 +32,7 @@ public abstract class TupleToMessage implements Serializable {
         determineRoutingKey(input),
         specifyContentType(input),
         specifyContentEncoding(input),
+        specifyExpiration(input),
         specifyMessagePersistence(input)
     );
   }
@@ -99,6 +100,16 @@ public abstract class TupleToMessage implements Serializable {
    */
   protected String specifyContentEncoding(Tuple input) {
     return null;
+  }
+
+  /**
+   * Specify whether the message should expire after an interval of sitting in the queue.
+   *
+   * @param input the incoming tuple
+   * @return an value for expiration if applicable
+   */
+  protected String specifyExpiration(Tuple input) {
+      return null;
   }
 
   /**

--- a/src/main/java/io/latent/storm/rabbitmq/config/ConfigUtils.java
+++ b/src/main/java/io/latent/storm/rabbitmq/config/ConfigUtils.java
@@ -5,7 +5,9 @@ import java.util.Map;
 public class ConfigUtils
 {
   public static String getFromMap(String key, Map<String, Object> map) {
-    return map.get(key).toString();
+    Object value = map.get(key);
+    if (value == null) return null;
+    return value.toString();
   }
   
   public static String getFromMap(String key, Map<String, Object> map, String defaultValue) {

--- a/src/test/java/io/latent/storm/rabbitmq/config/ConfigAvailableHostsTest.java
+++ b/src/test/java/io/latent/storm/rabbitmq/config/ConfigAvailableHostsTest.java
@@ -1,0 +1,23 @@
+package io.latent.storm.rabbitmq.config;
+
+import com.rabbitmq.client.Address;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Created by justinh on 2/22/16.
+ */
+public class ConfigAvailableHostsTest {
+
+    @Test
+    public void fromString() throws Exception {
+        final ConfigAvailableHosts hosts = ConfigAvailableHosts.fromString("123.123.123.123|456.456.456.456");
+        assertFalse(hosts.isEmpty());
+        assertEquals(hosts.toAddresses().length, 2);
+        assertEquals(hosts.toAddresses()[0], new Address("123.123.123.123"));
+        assertEquals(hosts.toAddresses()[1], new Address("456.456.456.456"));
+
+    }
+}


### PR DESCRIPTION
In trying to setup a spout that does not use HA, the code for checking for HA throws a NPE in this code here since it assumes that any key looked up in the map has a value. For HA Hosts, the only acceptable value other than hosts is null.
